### PR TITLE
file registry bug on folders that exist but are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Utils functions chunked and flatten_rows_dict in getl/common/upsert.py
 
+### Fixed
+- When checking if a file registry exists in an empty directory or in a S3 prefix that doesn't exist, a different exception is raised
+
 ## [1.4.2] - 2020-09-30
 - Critical bugfix for Hive table creation.
 

--- a/getl/fileregistry/fileregistry_utils.py
+++ b/getl/fileregistry/fileregistry_utils.py
@@ -16,11 +16,19 @@ def update_date_lifted(delta_table: "DeltaTable") -> None:
 
 
 def fetch_file_registry(path: str, spark: SparkSession) -> Union[DataFrame, None]:
-    """Retrun a dataframe if one can be found otherwise None."""
+    """Return a dataframe if one can be found otherwise None."""
     try:
-        return spark.read.load(path, format="delta")
+        dataframe = spark.read.load(path, format="delta")
+        if dataframe.rdd.isEmpty():
+            return None
+        return dataframe
     except AnalysisException as spark_exception:
-        exceptions = ["Incompatible format detected", "doesn't exist"]
+        exceptions = [
+            "Incompatible format detected",
+            "doesn't exist",
+            "is not a Delta table",
+        ]
 
-        if not any([e in str(spark_exception) for e in exceptions]):
+        if not any(e in str(spark_exception) for e in exceptions):
             raise spark_exception
+        return None

--- a/tests/getl/test_fileregistry_utils.py
+++ b/tests/getl/test_fileregistry_utils.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from pyspark.sql import types as T
+
+import getl.fileregistry.fileregistry_utils as fr_utils
+
+
+def test_doesnt_exist(spark_session, tmp_path):
+    assert (
+        fr_utils.fetch_file_registry(str(tmp_path / "unknown"), spark_session) is None
+    )
+
+
+def test_empty(spark_session, tmp_path):
+    assert fr_utils.fetch_file_registry(str(tmp_path), spark_session) is None
+
+
+def test_no_data(spark_session, tmp_path):
+    file_registry_path = str(tmp_path)
+
+    schema = T.StructType(
+        [
+            T.StructField("file_path", T.StringType(), True),
+            T.StructField("prefix_date", T.TimestampType(), True),
+            T.StructField("date_lifted", T.TimestampType(), True),
+        ]
+    )
+    dataframe = spark_session.createDataFrame([], schema)
+    dataframe.write.save(path=file_registry_path, format="delta", mode="overwrite")
+
+    assert fr_utils.fetch_file_registry(file_registry_path, spark_session) is None
+
+
+def test_has_data(spark_session, tmp_path):
+    file_registry_path = str(tmp_path)
+
+    schema = T.StructType(
+        [
+            T.StructField("file_path", T.StringType(), True),
+            T.StructField("prefix_date", T.TimestampType(), True),
+            T.StructField("date_lifted", T.TimestampType(), True),
+        ]
+    )
+    dataframe = spark_session.createDataFrame(
+        [("/path/to/file", datetime.now(), None)], schema
+    )
+    dataframe.write.save(path=file_registry_path, format="delta", mode="overwrite")
+
+    assert fr_utils.fetch_file_registry(file_registry_path, spark_session) is not None


### PR DESCRIPTION
### Description

When a file registry is being checked if it exists or not, a different exception is raised when the directory is empty in pyspark 3.

This happens also when working with s3 paths.

```python
try:
    spark.read.load(file_registry_path, format="delta")
except Exception as e:
    print(str(e))
```

Output:

```
`s3://bucket/path/to/file-registry/` is not a Delta table.;
```

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added **tests** that prove my fix is effective or that my feature works
- [x] I have added necessary **documentation** (if appropriate)
- [x] I have updated the **CHANGELOG.md**
