### PR TITLE
BD-1803 Create empty array<string> column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bugfix: When creating empty arrays they looked like array<null>. That is not supported by spark 3 so instead we create empty array<string>
+
 ## [1.6.2] - 2020-10-29
 ### Fixed
 - Bugfix for loading empty directories with batch_delta using spark 3.0

--- a/getl/blocks/transform/transform.py
+++ b/getl/blocks/transform/transform.py
@@ -279,7 +279,7 @@ def _add_new_column(
 ) -> DataFrame:
     """Add a new column to the dataframe."""
     if default_value == "array()":
-        return dataframe.withColumn(column_name, F.array())
+        return dataframe.withColumn(column_name, F.array().cast("array<string>"))
 
     return dataframe.withColumn(column_name, F.lit(None))
 

--- a/tests/getl/transform/test_transform.py
+++ b/tests/getl/transform/test_transform.py
@@ -283,10 +283,7 @@ def test_filter_success(predicate, princess_names, spark_session):
                     "alias": "test",
                 },
             ],
-            [
-                "DataFrame[device: array<string>, test: array<string>]",
-                "DataFrame[device: array<null>, test: array<null>]",
-            ],
+            ["DataFrame[device: array<string>, test: array<string>]"],
         ),
         (
             [{"col": "age", "alias": "years", "cast": "string"}],


### PR DESCRIPTION
### Description

Generate empty array<string>, before it generated array<null> that is not supported in spark 3


### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added **tests** that prove my fix is effective or that my feature works
- [x] I have added necessary **documentation** (if appropriate)
- [x] I have updated the **CHANGELOG.md**
