### PR TITLE
Change fileregistry::delta_diff to read all data if the start date is before the first version of the delta table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- The `fileregistry::delta_diff` fileregistry will read all data if the default start date is before the first version of the delta table
 
 ## [1.10.0] - 2021-01-22
 ### Added


### PR DESCRIPTION
### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added **tests** that prove my fix is effective or that my feature works
- [x] I have added necessary **documentation** (if appropriate)
- [x] I have updated the **CHANGELOG.md**
