### PR TITLE
BD-2176 Add more options for defining JSON schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+- Add possibility to define JSON schema with JSON or PySpark code
 
 ## [2.7.3] - 2021-11-18
 - Add support to read the Delta change data feed when running on Databricks platform

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,8 @@ jobs:
         -Dsonar.projectKey=GETL \
         -Dsonar.sources=. \
         -Dsonar.host.url=https://sonarcloud.io \
-        -Dsonar.login=$(SONAR_TOKEN)
+        -Dsonar.login=$(SONAR_TOKEN) \
+        -Dsonar.python.version=3
     displayName: 'Sonar scanner'
 
 - job: Publish

--- a/tests/getl/blocks/load/data/sample.json
+++ b/tests/getl/blocks/load/data/sample.json
@@ -1,3 +1,3 @@
-{"name":"Mark Steelspitter","empid":9,"happy":false,"gear":{"helmet":"vikinghelmet","armor":"steelplate","shoulder-pads":"sturdyleather"}}
+{"name":"Mark Steelspitter","empid":9,"happy":false,"gear":{"helmet":"vikinghelmet","armor":null,"shoulder-pads":"sturdyleather"}}
 {"name":"Mark Two","empid":10,"happy":true,"gear":{"helmet":"helmet","armor":"steelplate","shoulder-pads":"sturdyleather"}}
 {"name":"Mark Second","empid":11,"happy":false,"gear":{"helmet":"none","armor":"steelplate","shoulder-pads":"sturdyleather"}}


### PR DESCRIPTION
Add possibility to define JSON schema with JSON or PySpark code

### Description

Please describe your pull request!


### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added **tests** that prove my fix is effective or that my feature works
- [x] I have added necessary **documentation** (if appropriate)
- [x] I have updated the **CHANGELOG.md**
- [ ] I have checked [SonarCloud](https://sonarcloud.io/dashboard?id=GETL) for issues on my branch
